### PR TITLE
Add logging and check intervals to Ethernet link state initialization

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -29,6 +29,7 @@
 #define LEFTPORT 0		/* port ID of the "Left" port */
 #define RIGHTPORT 1		/* port ID of the "Right" port */
 #define MAX_PORT_TRIALS 100     /* rte_eth_link_get() is attempted maximum so many times, and error is reported if still unsuccessful */
+#define LINK_CHECK_INTERVAL 100 /* ms, interval between two attempts of rte_eth_link_get() */
 #define START_DELAY 2000        /* Delay (ms) before senders start sending, used for synchronized start. Beware that DUT NICs need time to get ready! */
 #define TOLERANCE 1.00001       /* Maximum allowed time inaccuracy, 1.00001 allows 0.001% more time for sending */
 #define N 40			/* used for PDV and varport: all frames exist is N copies to mitigate the problem of write after send */

--- a/throughput.cc
+++ b/throughput.cc
@@ -784,23 +784,32 @@ int Throughput::init(const char *argv0, uint16_t leftport, uint16_t rightport) {
     rte_eth_promiscuous_enable(rightport);
   }
 
-  // check links' states (wait for coming up), try maximum MAX_PORT_TRIALS times
+  // check links' states (wait for coming up), try maximum MAX_PORT_TRIALS times and sleep for LINK_CHECK_INTERVAL milliseconds between two trials
+  // Left link check
   trials=0;
+  std::cout << "Info: Waiting for Left Ethernet port link..." << std::endl;
   do {
     if ( trials++ == MAX_PORT_TRIALS ) { 
       std::cerr << "Error: Left Ethernet port is DOWN, Tester exits." << std::endl;
       return -1;
     }
+  rte_delay_ms(LINK_CHECK_INTERVAL); // wait for LINK_CHECK_INTERVAL milliseconds before the next trial
   rte_eth_link_get(leftport, &link_info);
   } while ( link_info.link_status == RTE_ETH_LINK_DOWN );
+  std::cout << "Info: Left Ethernet port link is UP:" << link_info.link_speed << " Mbps" << std::endl;
+
+  // Right link check
   trials=0;
+  std::cout << "Info: Waiting for Right Ethernet port link..." << std::endl;
   do {
     if ( trials++ == MAX_PORT_TRIALS ) {
       std::cerr << "Error: Right Ethernet port is DOWN, Tester exits." << std::endl;
       return -1;
     }
+  rte_delay_ms(LINK_CHECK_INTERVAL); // wait for LINK_CHECK_INTERVAL milliseconds before the next trial
   rte_eth_link_get(rightport, &link_info);
   } while ( link_info.link_status == RTE_ETH_LINK_DOWN );
+  std::cout << "Info: Right Ethernet port link is UP:" << link_info.link_speed << " Mbps" << std::endl;
 
   // Some sanity checks: NUMA node of the cores and of the NICs are matching or not...
   if ( numa_available() == -1 )


### PR DESCRIPTION
This PR adds explicit logging and a brief delay to the existing link state checks in `siitperf`. This provides better visibility into the NIC initialization process and negotiated link speeds, making it much easier to debug future linkrate issues.

Changes:
- **Configuration:** Added a `LINK_CHECK_INTERVAL` macro (with a default value of _100ms_) in `defines.h` to standardize the wait time.
- **Polling rate:** Added [`rte_delay_ms(LINK_CHECK_INTERVAL)`](https://doc.dpdk.org/api/rte__cycles_8h.html#af73b844d50b98de74b1a0e1730262f85) to the link check process to give the NICs time to update their state between polling attempts.
- **Link State Logging:** Added logging messages to explicitly log when the application is waiting for the Left and Right Ethernet ports to come up.
- **Link Speed Logging:** Added logging to report the actual negotiated link speed ([`link_info.link_speed`](https://doc.dpdk.org/api-1.6/structrte__eth__link.html#a7d93770cafbfd72bb3bbd1aaec9894ab) in _Mbps_) once each port connects successfully.